### PR TITLE
cake example using active-slick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bin/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet/
+
+# IntelliJ specific
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.0.2",
-  "io.strongtyped" %% "active-slick" % "0.3.2-SNAPSHOT",
+  "io.strongtyped" %% "active-slick" % "0.3.2",
   "org.postgresql" % "postgresql" % "9.3-1101-jdbc41",
   "com.h2database" % "h2" % "1.3.170",
   "junit" % "junit" % "4.10" % "test",

--- a/src/main/scala/com/dtc/deltasoft/entity/DbRunner.scala
+++ b/src/main/scala/com/dtc/deltasoft/entity/DbRunner.scala
@@ -1,0 +1,34 @@
+package com.dtc.deltasoft.entity
+
+import slick.jdbc.meta.MTable
+import slick.lifted.AppliedCompiledFunction
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import slick.jdbc.JdbcBackend.Database
+
+
+trait DbRunner {
+  this: DriverComponent =>
+
+  def db: Database
+
+  import driver.api._
+
+  def run[R](dbioAction: DBIOAction[R, NoStream, Nothing]) = Await.result(db.run(dbioAction), Duration.Inf)
+
+  // Running a query
+  def run[E, U, C[_]](query: Query[E, U, C]) = Await.result(db.run(query.result), Duration.Inf)
+
+  // Running a compiled query
+  def run[PU, R <: Rep[_], RU](acf: AppliedCompiledFunction[PU, R, RU]) = Await.result(db.run(acf.result), Duration.Inf)
+
+  def dropExistingTables(tables: TableQuery[_ <: Table[_]]*) = {
+    val matchingTables = tables filter (table => run(MTable.getTables("%")).
+      map(_.name.name.toUpperCase) contains (table.baseTableRow.tableName))
+    matchingTables.toList map (_.schema) match {
+      case Nil =>
+      case x   => run(x reduceLeft (_ ++ _) drop)
+    }
+  }
+}

--- a/src/main/scala/com/dtc/deltasoft/entity/DriverComponent.scala
+++ b/src/main/scala/com/dtc/deltasoft/entity/DriverComponent.scala
@@ -1,0 +1,16 @@
+package com.dtc.deltasoft.entity
+
+import io.strongtyped.active.slick.JdbcProfileProvider
+
+trait DriverComponent {
+
+  type DriverType <: slick.driver.JdbcProfile
+  val driver: DriverType
+
+  trait ConfigurableProfileProvider extends JdbcProfileProvider {
+
+    type JP = DriverType
+    val jdbcProfile = driver
+  }
+
+}

--- a/src/main/scala/com/dtc/deltasoft/entity/Suburb.scala
+++ b/src/main/scala/com/dtc/deltasoft/entity/Suburb.scala
@@ -5,8 +5,9 @@ import io.strongtyped.active.slick._
 import io.strongtyped.active.slick.Lens._
 
 trait SuburbProfile {
+  this: DriverComponent =>
 
-  object SuburbRepo extends EntityActions with ConfiguredProfileProvider {
+  object SuburbRepo extends EntityActions with ConfigurableProfileProvider {
 
     import jdbcProfile.api._
 

--- a/src/test/scala/com/dtc/deltasoft/entity/SuburbSuite.scala
+++ b/src/test/scala/com/dtc/deltasoft/entity/SuburbSuite.scala
@@ -15,7 +15,7 @@ import slick.jdbc.JdbcBackend.Database
 @RunWith(classOf[JUnitRunner])
 class SuburbSpec extends FunSpec with Matchers {
 
-  val dal = new Cake(H2Driver, Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver"))
+  val dal = new DAL(H2Driver, Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver"))
 
   import dal.driver.api._
   import dal._
@@ -36,7 +36,7 @@ class SuburbSpec extends FunSpec with Matchers {
   }
 }
 
-class Cake[D <: JdbcProfile](val driver: D, val db: Database) extends SuburbProfile with DbRunner with DriverComponent {
+class DAL[D <: JdbcProfile](val driver: D, val db: Database) extends SuburbProfile with DbRunner with DriverComponent {
 
   type DriverType = D
 }

--- a/src/test/scala/com/dtc/deltasoft/entity/SuburbSuite.scala
+++ b/src/test/scala/com/dtc/deltasoft/entity/SuburbSuite.scala
@@ -4,7 +4,9 @@ import org.junit.runner.RunWith
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
+import slick.driver.{H2Driver, JdbcProfile}
 import scala.concurrent.ExecutionContext.Implicits.global
+import slick.jdbc.JdbcBackend.Database
 
 /**
  * Unit test suite for the [[Suburb]] entity.
@@ -13,14 +15,15 @@ import scala.concurrent.ExecutionContext.Implicits.global
 @RunWith(classOf[JUnitRunner])
 class SuburbSpec extends FunSpec with Matchers {
 
-  val dal = new ConfiguredProfileProvider with SuburbProfile
-  import dal.jdbcProfile.api._
+  val dal = new Cake(H2Driver, Database.forURL("jdbc:h2:mem:test1", driver = "org.h2.Driver"))
+
+  import dal.driver.api._
   import dal._
 
   describe("A Suburb entity") {
     describe("should support schema updates including") {
       it("table creation") {
-//        dropExistingTables(SuburbRepo.tableQuery)
+        //        dropExistingTables(SuburbRepo.tableQuery)
         dal.run(SuburbRepo.createSchema)
       }
     }
@@ -31,4 +34,9 @@ class SuburbSpec extends FunSpec with Matchers {
       }
     }
   }
+}
+
+class Cake[D <: JdbcProfile](val driver: D, val db: Database) extends SuburbProfile with DbRunner with DriverComponent {
+
+  type DriverType = D
 }


### PR DESCRIPTION
Hi Peter,

Here is an example on how to build a cake using active-slick and a component that will bind your driver at compilation time.

Code compiles, but test doesn't run. I won't have time to look further. You'll also need to adapt it for pick the string from your config, but this should be trivial.

There is also a DbRunner trait where I moved your code for running db queries as having it in your ProfileProvider can be problematic.

I would recommend to not use Await and simply return the Future. The philosophy is to not block, but combine your Futures and let a framework like Play or Spray take care of reacting once the Future is completed. 

 I hope you can find some inspiration from that example.
